### PR TITLE
Change publish alias from 'p' to 'pub'

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ argument utilizes the `version` arguments of the `np` library.
 
 ```shell
 ngl publish <version>
-ngl p <version>
+ngl pub <version>
 npm run tagVersion <version>
 ```
 

--- a/commands/npm/index.js
+++ b/commands/npm/index.js
@@ -17,7 +17,7 @@ const getNpmCommand = (command, args) => {
         case 'l':
         case 'lint':
             return 'lint';
-        case 'p':
+        case 'pub':
         case 'publish':
             return ['tagVersion'].concat(args);
         case 'v':

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const getCommandName = (command) => {
         case 'build':
         case 'l':
         case 'lint':
-        case 'p':
+        case 'pub':
         case 'publish':
         case 'serve':
         case 't':


### PR DESCRIPTION
A fix for #45 

It changes the alias for the ```publish``` command to be ```pub``` instead of ```p```.

Removing the conflict with the alias for ```pipe```.