### PR TITLE
Feature/add tslint prefix

### DIFF
--- a/commands/component/index.js
+++ b/commands/component/index.js
@@ -11,9 +11,11 @@ const files = utilities.files;
 const inputs = utilities.inputs;
 const opts = utilities.options;
 let logger;
+let prefix;
 
 module.exports = function createComponent(rootDir, selector) {
     logger = logging.create('Component');
+    prefix = files.selectorPrefix ? `${files.selectorPrefix}-` : '';
 
     const options = opts.parseOptions(Array.from(arguments).slice(hasSelector(selector) ? 2 : 1), [
         'default', 'defaults', 'd',
@@ -37,11 +39,13 @@ const constructWithDefaults = (rootDir, selector, options) => {
         const styleAnswers = getKnownStyle(false, selectorAnswers);
         const templateAnswers = getKnownTemplate(false, selectorAnswers);
         const lifecycleAnswers = getKnownLifecycleHooks('');
+        const prefixAnswer = getPrefixAnswer();
 
         const answers = selectorAnswers.concat(
             styleAnswers,
             templateAnswers,
-            lifecycleAnswers
+            lifecycleAnswers,
+            prefixAnswer
         );
 
         return Promise.resolve()
@@ -57,7 +61,9 @@ const hasSelector = (selector) => selector && selector[0] !== '-';
 
 const inquire = (rootDir, selector, options) => {
     const remaining = getRemainingQuestions(selector, options);
-    const knownAnswers = remaining.answers;
+    const prefixAnswer = getPrefixAnswer();
+    const knownAnswers = remaining.answers.concat(prefixAnswer);
+;
     const questions = remaining.questions.reduce((all, method) => all.concat(method(knownAnswers)), []);
 
     return erector.inquire(questions)
@@ -72,6 +78,8 @@ const construct = (answers, options = {}) => {
     notifyUser(answers, forExamples);
     return results;
 };
+
+const getPrefixAnswer = () => [{ name: 'prefix', answer: prefix }];
 
 const getRemainingQuestions = (selectorName, options) => {
     const all = [
@@ -103,8 +111,8 @@ const getSelector = (selector) => {
 };
 
 const getKnownSelector = (selector) => [
-    { answer: selector, name: 'selector' },
-    { answer: caseConvert.dashToCap(selector) + 'Component', name: 'componentName' }
+    { name: 'selector', answer: selector },
+    { name: 'componentName', answer: caseConvert.dashToCap(selector) + 'Component' }
 ];
 
 const getSelectorQuestions = () => [

--- a/commands/component/index.js
+++ b/commands/component/index.js
@@ -15,7 +15,7 @@ let prefix;
 
 module.exports = function createComponent(rootDir, selector) {
     logger = logging.create('Component');
-    prefix = files.selectorPrefix ? `${files.selectorPrefix}-` : '';
+    prefix = files.selectorPrefix() ? `${files.selectorPrefix()}-` : '';
 
     const options = opts.parseOptions(Array.from(arguments).slice(hasSelector(selector) ? 2 : 1), [
         'default', 'defaults', 'd',

--- a/commands/component/index.js
+++ b/commands/component/index.js
@@ -15,7 +15,7 @@ let prefix;
 
 module.exports = function createComponent(rootDir, selector) {
     logger = logging.create('Component');
-    prefix = files.selectorPrefix() ? `${files.selectorPrefix()}-` : '';
+    prefix = files.selectorPrefix('component-selector') ? `${files.selectorPrefix('component-selector')}-` : '';
 
     const options = opts.parseOptions(Array.from(arguments).slice(hasSelector(selector) ? 2 : 1), [
         'default', 'defaults', 'd',

--- a/commands/component/templates/app.ts
+++ b/commands/component/templates/app.ts
@@ -3,7 +3,7 @@ import {
 } from '@angular/core';
 
 @Component({
-    selector: '{{ selector }}',
+    selector: '{{ prefix }}{{ selector }}',
     {{ styleAttribute }}: [{{ styles }}],
     {{ templateAttribute }}: {{ template }}
 })

--- a/commands/directive/index.js
+++ b/commands/directive/index.js
@@ -16,7 +16,7 @@ let prefix;
 
 module.exports = function createDirective(rootDir, name) {
     logger = logging.create('Directive');
-    prefix = files.selectorPrefix();
+    prefix = files.selectorPrefix('directive-selector');
 
     const providedOptions = Array.from(arguments).slice(name && name[0] !== '-' ? 2 : 1);
     const options = opts.parseOptions(providedOptions, [

--- a/commands/directive/index.js
+++ b/commands/directive/index.js
@@ -16,7 +16,7 @@ let prefix;
 
 module.exports = function createDirective(rootDir, name) {
     logger = logging.create('Directive');
-    prefix = files.selectorPrefix;
+    prefix = files.selectorPrefix();
 
     const providedOptions = Array.from(arguments).slice(name && name[0] !== '-' ? 2 : 1);
     const options = opts.parseOptions(providedOptions, [

--- a/commands/directive/templates/test.ts
+++ b/commands/directive/templates/test.ts
@@ -4,7 +4,7 @@ import {
     TestBed
 } from '@angular/core/testing';
 
-import { {{ className }} } from './{{ name }}.directive';
+import { {{ className }} } from './{{ directiveName }}.directive';
 
 describe('{{ className }}', () => {
     it('', () => {

--- a/commands/initial/index.js
+++ b/commands/initial/index.js
@@ -88,7 +88,7 @@ const getQuestions = () => {
     return [
         { defaultAnswer: defaultName, name: 'name', question: `Library name:`, transform: checkNameFormat },
         { name: 'packageName', useAnswer: 'name', transform: extractPackageName },
-        { defaultAnswer: '', name: 'prefix', question: `Prefix (component/directive selector):` },
+        { allowBlank: true, defaultAnswer: '', name: 'prefix', question: `Prefix (component/directive selector):` },
         { defaultAnswer: (answers) => caseConvert.dashToWords(answers[1].answer), name: 'readmeTitle', question: 'README Title:' },
         { name: 'repoUrl', question: 'Repository URL:' },
         { name: 'git', question: 'Reinitialize Git project (y/N)?', transform: inputs.createYesNoValue('n') },

--- a/commands/initial/index.js
+++ b/commands/initial/index.js
@@ -88,6 +88,7 @@ const getQuestions = () => {
     return [
         { defaultAnswer: defaultName, name: 'name', question: `Library name:`, transform: checkNameFormat },
         { name: 'packageName', useAnswer: 'name', transform: extractPackageName },
+        { defaultAnswer: '', name: 'prefix', question: `Prefix (component/directive selector):` },
         { defaultAnswer: (answers) => caseConvert.dashToWords(answers[1].answer), name: 'readmeTitle', question: 'README Title:' },
         { name: 'repoUrl', question: 'Repository URL:' },
         { name: 'git', question: 'Reinitialize Git project (y/N)?', transform: inputs.createYesNoValue('n') },

--- a/commands/initial/templates/tslint.json
+++ b/commands/initial/templates/tslint.json
@@ -98,8 +98,8 @@
             "check-type"
         ],
 
-        "directive-selector": [true, "attribute", "", "camelCase"],
-        "component-selector": [true, "element", "", "kebab-case"],
+        "directive-selector": [true, "attribute", "{{ prefix }}", "camelCase"],
+        "component-selector": [true, "element", "{{ prefix }}", "kebab-case"],
         "use-input-property-decorator": true,
         "use-output-property-decorator": true,
         "use-host-property-decorator": true,

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -910,7 +910,7 @@ tap.test('command: component', (suite) => {
     });
 
     suite.test('should scaffold the app & spec files with a prefix', (test) => {
-        filesSelectorPrefix.value('ngfl');
+        filesSelectorPrefix.returns('ngfl');
 
         const answers = [
             { answer: 'donut-dance', name: 'selector' },

--- a/test/directive.spec.js
+++ b/test/directive.spec.js
@@ -23,6 +23,7 @@ let construct;
 let creator;
 let dashToCap;
 let getTemplates;
+let filesSelectorPrefix;
 let inquire;
 let log;
 let logger;
@@ -37,6 +38,7 @@ tap.test('command: directive', (suite) => {
         checkForExamples = sandbox.stub(opts, 'checkIsForExamples');
         construct = sandbox.stub(erector, 'construct');
         creator = sandbox.stub(files.resolver, 'create');
+        filesSelectorPrefix = sandbox.stub(files, 'selectorPrefix');
         getTemplates = sandbox.stub(files, 'getTemplates');
         inquire = sandbox.stub(erector, 'inquire');
         logger = sandbox.stub(logging, 'create');
@@ -99,7 +101,7 @@ tap.test('command: directive', (suite) => {
 
     suite.test('should ask no questions if a dash-case directive name is provided', (test) => {
         const answers = [
-            { answer: 'bacon-blast', name: 'name' },
+            { answer: 'bacon-blast', name: 'directiveName' },
             { answer: 'PascalCaseDirective', name: 'className' },
             { answer: 'camelCase', name: 'selector' }
         ];
@@ -111,6 +113,7 @@ tap.test('command: directive', (suite) => {
         dashToCamel.returns('camelCase');
         dashToCap.returns('PascalCase');
         checkDashFormat.returns(true);
+
         test.plan(2);
         make('bacon-blast').then(() => {
             test.notOk(inquire.called);
@@ -133,19 +136,19 @@ tap.test('command: directive', (suite) => {
 
             test.ok(inquire.calledWith([
                 {
-                    name: 'name',
+                    name: 'directiveName',
                     question: 'Directive name (in dash-case):',
                     transform: caseConvert.testIsDashFormat
                 },
                 {
                     name: 'selector',
-                    transform: caseConvert.dashToCamel,
-                    useAnswer: 'name'
+                    transform: sinon.match.instanceOf(Function),
+                    useAnswer: 'directiveName'
                 },
                 {
                     name: 'className',
                     transform: sinon.match.instanceOf(Function),
-                    useAnswer: 'name'
+                    useAnswer: 'directiveName'
                 }
             ]));
 
@@ -159,7 +162,7 @@ tap.test('command: directive', (suite) => {
         const answers = [
             {
                 answer: 'burger-blitz',
-                name: 'name'
+                name: 'directiveName'
             },
             {
                 answer: 'burgerBlitz',
@@ -186,11 +189,11 @@ tap.test('command: directive', (suite) => {
                 dirname,
                 [
                     {
-                        destination: '/created/src/directives/{{ name }}.directive.ts',
+                        destination: '/created/src/directives/{{ directiveName }}.directive.ts',
                         name: 'app.ts'
                     },
                     {
-                        destination: '/created/src/directives/{{ name }}.directive.spec.ts',
+                        destination: '/created/src/directives/{{ directiveName }}.directive.spec.ts',
                         name: 'test.ts'
                     }
                 ]
@@ -218,7 +221,7 @@ tap.test('command: directive', (suite) => {
         const answers = [
             {
                 answer: 'burger-blitz',
-                name: 'name'
+                name: 'directiveName'
             },
             {
                 answer: 'burgerBlitz',
@@ -246,11 +249,11 @@ tap.test('command: directive', (suite) => {
                 dirname,
                 [
                     {
-                        destination: '/created/examples/directives/{{ name }}.directive.ts',
+                        destination: '/created/examples/directives/{{ directiveName }}.directive.ts',
                         name: 'app.ts'
                     },
                     {
-                        destination: '/created/examples/directives/{{ name }}.directive.spec.ts',
+                        destination: '/created/examples/directives/{{ directiveName }}.directive.spec.ts',
                         name: 'test.ts'
                     }
                 ]
@@ -278,7 +281,7 @@ tap.test('command: directive', (suite) => {
         const answers = [
             {
                 answer: 'burger-blitz',
-                name: 'name'
+                name: 'directiveName'
             },
             {
                 answer: 'burgerBlitz',
@@ -314,7 +317,7 @@ tap.test('command: directive', (suite) => {
             `        expect(directive).toBeTruthy();\n` +
             `    });\n` +
             `});\n`;
-        // const getTemplates = sandbox.stub(files, 'getTemplates');
+
 
         construct.callThrough();
 

--- a/test/initial.spec.js
+++ b/test/initial.spec.js
@@ -2,6 +2,7 @@
 
 const childProcess = require('child_process');
 const erector = require('erector-set');
+const fs = require('fs');
 const path = require('path');
 const process = require('process');
 const sinon = require('sinon');
@@ -81,7 +82,7 @@ tap.test('command: initial', (suite) => {
     suite.test('should call erector.inquire with the questions to ask', (test) => {
         const createYesNo = sandbox.stub(inputs, 'createYesNoValue');
 
-        test.plan(22);
+        test.plan(25);
 
         mockErector.inquire.rejects();
         createYesNo.returns('"no" function');
@@ -100,24 +101,28 @@ tap.test('command: initial', (suite) => {
             test.equal(typeof questions[1].transform, 'function');
             test.equal(questions[1].useAnswer, 'name');
 
-            test.equal(typeof questions[2].defaultAnswer, 'function');
-            test.equal(questions[2].name, 'readmeTitle');
-            test.equal(questions[2].question, 'README Title:');
+            test.equal(typeof questions[2].defaultAnswer, 'string');
+            test.equal(questions[2].name, 'prefix');
+            test.equal(questions[2].question, 'Prefix (component/directive selector):');
 
-            test.equal(questions[3].name, 'repoUrl');
-            test.equal(questions[3].question, 'Repository URL:');
+            test.equal(typeof questions[3].defaultAnswer, 'function');
+            test.equal(questions[3].name, 'readmeTitle');
+            test.equal(questions[3].question, 'README Title:');
 
-            test.equal(questions[4].name, 'git');
-            test.equal(questions[4].question, 'Reinitialize Git project (y/N)?');
+            test.equal(questions[4].name, 'repoUrl');
+            test.equal(questions[4].question, 'Repository URL:');
+
+            test.equal(questions[5].name, 'git');
+            test.equal(questions[5].question, 'Reinitialize Git project (y/N)?');
             test.ok(createYesNo.calledWith('n'));
-            test.equal(questions[4].transform, '"no" function');
+            test.equal(questions[5].transform, '"no" function');
 
-            test.equal(questions[5].name, 'moduleName');
-            test.equal(typeof questions[5].transform, 'function');
-            test.equal(questions[5].useAnswer, 'packageName');
+            test.equal(questions[6].name, 'moduleName');
+            test.equal(typeof questions[6].transform, 'function');
+            test.equal(questions[6].useAnswer, 'packageName');
 
-            test.equal(questions[6].name, 'version');
-            test.equal(questions[6].question, 'Version:');
+            test.equal(questions[7].name, 'version');
+            test.equal(questions[7].question, 'Version:');
 
             test.ok(mockLog.calledWith('\x1b[31mError\x1b[0m'));
 
@@ -178,7 +183,7 @@ tap.test('command: initial', (suite) => {
         dashToCap.returns('WOW!');
 
         initial('./').then(() => {
-            const { transform } = mockErector.inquire.lastCall.args[0][5];
+            const { transform } = mockErector.inquire.lastCall.args[0][6];
             test.equal(transform('this is calm'), 'WOW!Module');
             test.end();
         });
@@ -193,7 +198,7 @@ tap.test('command: initial', (suite) => {
         dashToWords.returns('Herds of Words');
 
         initial('./').then(() => {
-            const { defaultAnswer } = mockErector.inquire.lastCall.args[0][2];
+            const { defaultAnswer } = mockErector.inquire.lastCall.args[0][3];
 
             test.equal(defaultAnswer([null, { answer: 'this-is-patrick' }]), 'Herds of Words');
             test.ok(dashToWords.calledWith('this-is-patrick'));
@@ -270,6 +275,7 @@ tap.test('command: initial', (suite) => {
         const answers = [
             { answer: '@myscope/fake-library', name: 'name' },
             { answer: 'fake-library', name: 'packageName' },
+            { answer: 'ngfl', name: 'prefix' },
             { answer: 'Fake Library', name: 'readmeTitle' },
             { answer: 'http://re.po', name: 'repoUrl' },
             { answer: false, name: 'git' },
@@ -306,6 +312,7 @@ tap.test('command: initial', (suite) => {
         const answers = [
             { answer: '@myscope/fake-library', name: 'name' },
             { answer: 'fake-library', name: 'packageName' },
+            { answer: 'ngfl', name: 'prefix' },
             { answer: 'Fake Library', name: 'readmeTitle' },
             { answer: 'http://re.po', name: 'repoUrl' },
             { answer: false, name: 'git' },
@@ -338,6 +345,7 @@ tap.test('command: initial', (suite) => {
         const answers = [
             { answer: '@myscope/fake-library', name: 'name' },
             { answer: 'fake-library', name: 'packageName' },
+            { answer: 'ngfl', name: 'prefix' },
             { answer: 'Fake Library', name: 'readmeTitle' },
             { answer: 'http://re.po', name: 'repoUrl' },
             { answer: true, name: 'git' },

--- a/test/initial.spec.js
+++ b/test/initial.spec.js
@@ -82,7 +82,7 @@ tap.test('command: initial', (suite) => {
     suite.test('should call erector.inquire with the questions to ask', (test) => {
         const createYesNo = sandbox.stub(inputs, 'createYesNoValue');
 
-        test.plan(25);
+        test.plan(26);
 
         mockErector.inquire.rejects();
         createYesNo.returns('"no" function');
@@ -102,6 +102,7 @@ tap.test('command: initial', (suite) => {
             test.equal(questions[1].useAnswer, 'name');
 
             test.equal(typeof questions[2].defaultAnswer, 'string');
+            test.equal(questions[2].allowBlank, true);
             test.equal(questions[2].name, 'prefix');
             test.equal(questions[2].question, 'Prefix (component/directive selector):');
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -76,3 +76,11 @@ exports.mockOnce = (sandbox, util, method) =>
 const argsPath = (args) => Array.from(args).join('/');
 
 exports.sinon = sinon;
+
+exports.mapQuestionsToQuestionName = (questions) => {
+  const map = {};
+
+  questions.forEach(question => map[question.name] = question);
+
+  return map;
+}

--- a/test/tools/utilities/case-convert.spec.js
+++ b/test/tools/utilities/case-convert.spec.js
@@ -106,6 +106,18 @@ tap.test('#dashToCamel should convert a dash-case to camel case', (test) => {
     test.end();
 });
 
+tap.test('#dashToPascal should convert a dash-case to PascalCase', (test) => {
+    const convert = caseConvert.dashToPascal;
+
+    test.plan(3);
+
+    test.equal(convert('this-is-camel-case'), 'ThisIsCamelCase');
+    test.equal(convert('this-is-camel-case', '~'), 'This~Is~Camel~Case');
+    test.equal(convert('startedAsACamel'), 'StartedAsACamel');
+
+    test.end();
+});
+
 tap.test('#dashToCap should convert a dash-case to Pascal case', (test) => {
     const convert = caseConvert.dashToCap;
 

--- a/test/tools/utilities/files.spec.js
+++ b/test/tools/utilities/files.spec.js
@@ -472,3 +472,80 @@ tap.test('.librarianVersions', (suite) => {
 
     suite.end();
 });
+
+tap.test('.selectorPrefix', (suite) => {
+    const selectorPrefix = files.selectorPrefix;
+    const include = sinon.stub(files, 'include');
+
+    suite.test('should read the prefix setting from tslint.json', (test) => {
+        include.returns({
+            rules: {
+                'directive-selector': [
+                    true,
+                    "attribute",
+                    "ngfl",
+                    "camelCase"
+                ],
+            }
+        });
+
+        test.plan(1);
+
+        test.equal(selectorPrefix(), 'ngfl');
+
+        include.restore();
+
+        test.end();
+    });
+
+    suite.test('should read the empty prefix from tslint.json', (test) => {
+        include.returns({
+            rules: {
+                'directive-selector': [
+                    true,
+                    "attribute",
+                    "",
+                    "camelCase"
+                ],
+            }
+        });
+
+        test.plan(1);
+
+        test.equal(selectorPrefix(), '');
+
+        include.restore();
+
+        test.end();
+    });
+
+    suite.test('should return empty prefix if directive-selector is not set', (test) => {
+        include.returns({
+            rules: {
+            }
+        });
+
+        test.plan(1);
+
+        test.equal(selectorPrefix(), '');
+
+        include.restore();
+
+        test.end();
+    });
+
+    suite.test('should return empty prefix if rules is not set', (test) => {
+        include.returns({
+        });
+
+        test.plan(1);
+
+        test.equal(selectorPrefix(), '');
+
+        include.restore();
+
+        test.end();
+    });
+
+    suite.end();
+});

--- a/test/tools/utilities/files.spec.js
+++ b/test/tools/utilities/files.spec.js
@@ -475,23 +475,47 @@ tap.test('.librarianVersions', (suite) => {
 
 tap.test('.selectorPrefix', (suite) => {
     const selectorPrefix = files.selectorPrefix;
-    const include = sinon.stub(files, 'include');
 
-    suite.test('should read the prefix setting from tslint.json', (test) => {
+    suite.test('should read the prefix directive-selector setting from tslint.json', (test) => {
+        const include = sinon.stub(files, 'include');
+
         include.returns({
             rules: {
                 'directive-selector': [
                     true,
-                    "attribute",
-                    "ngfl",
-                    "camelCase"
+                    'attribute',
+                    'ngfl',
+                    'camelCase'
                 ],
             }
         });
 
         test.plan(1);
 
-        test.equal(selectorPrefix(), 'ngfl');
+        test.equal(selectorPrefix('directive-selector'), 'ngfl');
+
+        include.restore();
+
+        test.end();
+    });
+
+    suite.test('should read the prefix directive-selector setting from tslint.json', (test) => {
+        const include = sinon.stub(files, 'include');
+
+        include.returns({
+            rules: {
+                'directive-selector': [
+                    true,
+                    'attribute',
+                    'ngfl',
+                    'camelCase'
+                ],
+            }
+        });
+
+        test.plan(1);
+
+        test.equal(selectorPrefix('directive-selector'), 'ngfl');
 
         include.restore();
 
@@ -499,20 +523,22 @@ tap.test('.selectorPrefix', (suite) => {
     });
 
     suite.test('should read the empty prefix from tslint.json', (test) => {
+        const include = sinon.stub(files, 'include');
+
         include.returns({
             rules: {
                 'directive-selector': [
                     true,
-                    "attribute",
-                    "",
-                    "camelCase"
+                    'attribute',
+                    '',
+                    'camelCase'
                 ],
             }
         });
 
         test.plan(1);
 
-        test.equal(selectorPrefix(), '');
+        test.equal(selectorPrefix('directive-selector'), '');
 
         include.restore();
 
@@ -520,6 +546,8 @@ tap.test('.selectorPrefix', (suite) => {
     });
 
     suite.test('should return empty prefix if directive-selector is not set', (test) => {
+        const include = sinon.stub(files, 'include');
+
         include.returns({
             rules: {
             }
@@ -527,7 +555,7 @@ tap.test('.selectorPrefix', (suite) => {
 
         test.plan(1);
 
-        test.equal(selectorPrefix(), '');
+        test.equal(selectorPrefix('directive-selector'), '');
 
         include.restore();
 
@@ -535,12 +563,14 @@ tap.test('.selectorPrefix', (suite) => {
     });
 
     suite.test('should return empty prefix if rules is not set', (test) => {
+        const include = sinon.stub(files, 'include');
+
         include.returns({
         });
 
         test.plan(1);
 
-        test.equal(selectorPrefix(), '');
+        test.equal(selectorPrefix('directive-selector'), '');
 
         include.restore();
 

--- a/tools/utilities/case-convert.js
+++ b/tools/utilities/case-convert.js
@@ -13,6 +13,12 @@ exports.dashToCamel = (value, replaceChar = '') =>
         match.replace('-', replaceChar).toUpperCase()
     );
 
+exports.dashToPascal = (value) => {
+  const dash = exports.dashToCamel(value);
+
+  return dash[0].toUpperCase() + exports.dashToCamel(dash.slice(1));
+}
+
 exports.dashToCap = (value, replaceChar = '') =>
     value[0].toUpperCase() +
     exports.dashToCamel(value.slice(1), replaceChar);

--- a/tools/utilities/case-convert.js
+++ b/tools/utilities/case-convert.js
@@ -13,8 +13,8 @@ exports.dashToCamel = (value, replaceChar = '') =>
         match.replace('-', replaceChar).toUpperCase()
     );
 
-exports.dashToPascal = (value) => {
-  const dash = exports.dashToCamel(value);
+exports.dashToPascal = (value, replaceChar = '') => {
+  const dash = exports.dashToCamel(value, replaceChar);
 
   return dash[0].toUpperCase() + exports.dashToCamel(dash.slice(1));
 }

--- a/tools/utilities/files.js
+++ b/tools/utilities/files.js
@@ -102,3 +102,21 @@ exports.librarianVersions = {
     checkIsBranch,
     get: getLibrarianVersion
 };
+
+const getSelectorPrefixFromTslintRules = () => {
+    const tslint = exports.include(exports.resolver.root('tslint.json'));
+    const directiveSelector = 'directive-selector';
+
+    let prefix = '';
+
+    if (tslint && tslint.rules && tslint.rules[directiveSelector]) {
+        prefix = getValueFromTslintRules(tslint, directiveSelector)[2];
+    }
+
+    return prefix;
+};
+
+const getValueFromTslintRules = (tslint, attribute) =>
+  tslint.rules[attribute];
+
+exports.selectorPrefix = getSelectorPrefixFromTslintRules();

--- a/tools/utilities/files.js
+++ b/tools/utilities/files.js
@@ -119,4 +119,4 @@ const getSelectorPrefixFromTslintRules = () => {
 const getValueFromTslintRules = (tslint, attribute) =>
   tslint.rules[attribute];
 
-exports.selectorPrefix = getSelectorPrefixFromTslintRules();
+exports.selectorPrefix = () => getSelectorPrefixFromTslintRules();

--- a/tools/utilities/files.js
+++ b/tools/utilities/files.js
@@ -103,14 +103,13 @@ exports.librarianVersions = {
     get: getLibrarianVersion
 };
 
-const getSelectorPrefixFromTslintRules = () => {
+const getSelectorPrefixFromTslintRules = (selector) => {
     const tslint = exports.include(exports.resolver.root('tslint.json'));
-    const directiveSelector = 'directive-selector';
 
     let prefix = '';
 
-    if (tslint && tslint.rules && tslint.rules[directiveSelector]) {
-        prefix = getValueFromTslintRules(tslint, directiveSelector)[2];
+    if (tslint && tslint.rules && tslint.rules[selector]) {
+        prefix = getValueFromTslintRules(tslint, selector)[2];
     }
 
     return prefix;
@@ -119,4 +118,4 @@ const getSelectorPrefixFromTslintRules = () => {
 const getValueFromTslintRules = (tslint, attribute) =>
   tslint.rules[attribute];
 
-exports.selectorPrefix = () => getSelectorPrefixFromTslintRules();
+exports.selectorPrefix = (selector) => getSelectorPrefixFromTslintRules(selector);


### PR DESCRIPTION
I thought it would be useful to set the library prefix when creating a new library.  Setting the prefix is an important part of creating libraries so that you can avoid collisions. 

I had some trouble with adding unit tests for the selector.  I tested the generation in a sample repo and the component test properly validates the selector, but I couldn't figure it out for the directive test.

Also there was a bug I fixed.  If you create a directive without a name it defaults to `asdf`.  It appears using `name` as the value for the `name` argument was causing an issue, so I changed it to `directiveName`. 

```
# in an example app... 
name="my-selector"; 
rm -rf src/directives; ./node_modules/angular-librarian/bin/index.js d ; 
vim src/directives/$name.directive.ts
# enter my-selector as the name
```