### PR TITLE
fix tslint.json template

### DIFF
--- a/commands/initial/templates/tslint.json
+++ b/commands/initial/templates/tslint.json
@@ -27,8 +27,19 @@
         "member-access": false,
         "member-ordering": [
             true,
-            "static-before-instance",
-            "variables-before-functions"
+            {
+                "order": [
+                    "public-static-field",
+                    "public-instance-field",
+                    "public-constructor",
+                    "private-static-field",
+                    "private-instance-field",
+                    "private-constructor",
+                    "public-instance-method",
+                    "protected-instance-method",
+                    "private-instance-method"
+                ]
+            }
         ],
         "no-arg": true,
         "no-bitwise": true,
@@ -70,21 +81,22 @@
         ],
         "radix": true,
         "semicolon": [
+            true,
             "always"
         ],
         "triple-equals": [
-        true,
+            true,
             "allow-null-check"
         ],
         "typedef-whitespace": [
-        true,
-        {
-            "call-signature": "nospace",
-            "index-signature": "nospace",
-            "parameter": "nospace",
-            "property-declaration": "nospace",
-            "variable-declaration": "nospace"
-        }
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
         ],
         "typeof-compare": true,
         "unified-signatures": true,
@@ -97,7 +109,6 @@
             "check-separator",
             "check-type"
         ],
-
         "directive-selector": [true, "attribute", "", "camelCase"],
         "component-selector": [true, "element", "", "kebab-case"],
         "use-input-property-decorator": true,
@@ -108,9 +119,6 @@
         "use-life-cycle-interface": true,
         "use-pipe-transform-interface": true,
         "component-class-suffix": true,
-        "directive-class-suffix": true,
-        "no-access-missing-member": true,
-        "templates-use-public": true,
-        "invoke-injectable": true
+        "directive-class-suffix": true
     }
 }


### PR DESCRIPTION
- correct syntax for member-ordering and semicolon options
- fix formatting issues
- remove unknown properties: no-access-missing-member, templates-use-public, invoke-injectable