### PR TITLE
Fixes decorators missing for Angular 5

### DIFF
--- a/commands/initial/templates/package.json
+++ b/commands/initial/templates/package.json
@@ -71,7 +71,7 @@
     "style-loader": "^0.19.0",
     "tslint": "^5.0.0",
     "tslint-loader": "^3.0.0",
-    "typescript": "^2.4.0",
+    "typescript": "2.4.2",
     "url-loader": "^0.6.0",
     "webpack": "^2.0.0",
     "webpack-dev-server": "^2.0.0",

--- a/commands/initial/templates/tasks/build.js
+++ b/commands/initial/templates/tasks/build.js
@@ -11,6 +11,7 @@ const inlineResources = require('./inline-resources');
 const rollup = require('./rollup');
 
 const colorize = librarianUtils.colorize;
+const execute = librarianUtils.execute;
 const rootDir = path.resolve(__dirname, '..');
 const buildDir = path.resolve(rootDir, 'build');
 const distDir = path.resolve(rootDir, 'dist');
@@ -34,15 +35,35 @@ const complete = (depth = 0) => {
 const evaluateExitCode = (exitCode) => {
     return exitCode === 0 ? Promise.resolve() : Promise.reject();
 };
-const compileCode = () => Promise.all([2015, 5].map((type) => {
-    const result = ngc(['--project', path.resolve(rootDir, `tsconfig.es${ type }.json`)]);
+const getAngularCompilerVersion = () => {
+    const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+    const lines = execute.execute(npm, ['list', '--depth=0', '@angular/compiler']).split(/\r?\n/);
+    const compilerLine = lines.find((line) => line.indexOf('@angular/compiler@') !== -1);
+    let version;
 
-    if (result.then !== undefined) {
-        result.then((exitCode) =>
-            evaluateExitCode(exitCode)
-        );
+    if (compilerLine) {
+        version = compilerLine.match(/\bangular\/compiler@[^\s]+\s?/) || [''];
+        version = version[0].trim().replace('angular/compiler@', '');
+    }
+
+    if (!version || version === '(empty)') {
+        Promise.reject('Angular Compiler is not installed!');
+    }
+
+    return version;
+};
+const compileCode = () => Promise.all([2015, 5].map((type) => {
+    const compilerVersion = getAngularCompilerVersion();
+    const majorCompilerVersion = +compilerVersion.split('.')[0];
+
+    if (majorCompilerVersion >= 5) {
+        const exitCode = ngc(['--project', path.resolve(rootDir, `tsconfig.es${ type }.json`)]);
+        return evaluateExitCode(exitCode);
     } else {
-        return evaluateExitCode(result);
+        ngc({ project: path.resolve(rootDir, `tsconfig.es${ type }.json`)})
+            .then((exitCode) => 
+            evaluateExitCode(exitCode)
+        )
     }
 }));
 const copyMetadata = () =>

--- a/commands/initial/templates/tasks/build.js
+++ b/commands/initial/templates/tasks/build.js
@@ -31,12 +31,20 @@ const complete = (depth = 0) => {
     const spaces = ' '.repeat(depth);
     console.info(colorize.colorize(`${ spaces }> Complete`, 'green'));
 };
-const compileCode = () => Promise.all([2015, 5].map((type) =>
-    ngc({ project: path.resolve(rootDir, `tsconfig.es${ type }.json`)})
-        .then((exitCode) =>
-            exitCode === 0 ? Promise.resolve() : Promise.reject()
-        )
-));
+const evaluateExitCode = (exitCode) => {
+    return exitCode === 0 ? Promise.resolve() : Promise.reject();
+};
+const compileCode = () => Promise.all([2015, 5].map((type) => {
+    const result = ngc(['--project', path.resolve(rootDir, `tsconfig.es${ type }.json`)]);
+
+    if (result.then !== undefined) {
+        result.then((exitCode) =>
+            evaluateExitCode(exitCode)
+        );
+    } else {
+        return evaluateExitCode(result);
+    }
+}));
 const copyMetadata = () =>
     copyGlobs(['**/*.d.ts', '**/*.metadata.json'], es2015Dir, distDir);
 const copyPackageFiles = () =>


### PR DESCRIPTION
NGC is not tested with Typescript compiler greater than 2.4.2. Set Typescript to exact version 2.4.2 as per Angular 5 migration guide.

Fixes issue #78 