### PR TITLE
Add support for rollup 0.52.1.

### DIFF
--- a/commands/initial/templates/package.json
+++ b/commands/initial/templates/package.json
@@ -59,7 +59,7 @@
     "phantomjs-prebuilt": "^2.1.7",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.3",
-    "rollup": "0.43.0",
+    "rollup": "0.52.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-sourcemaps": "0.4.2",


### PR DESCRIPTION
This PR adds support for Rollup 0.52.1. This is benificial because of a major rewrite of Rollup's tree shaking algorithm.

The changes are all concerning the [Unifying Rollup options](https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32) introduced in rollup 0.48+.

Closes [#86](https://github.com/gonzofish/angular-librarian/issues/86).