### PR TITLE
add autogeneration of compodoc after build

### DIFF
--- a/commands/initial/templates/package.json
+++ b/commands/initial/templates/package.json
@@ -7,7 +7,7 @@
   "es2015": "./{{ name }}.js",
   "typings": "./{{ packageName }}.d.ts",
   "scripts": {
-    "build": "node ./tasks/build",
+    "build": "node ./tasks/build && npm run compodoc",
     "g": "node ./node_modules/angular-librarian",
     "lint": "tslint ./src/**/*.ts",
     "postbuild": "rimraf build",
@@ -15,7 +15,8 @@
     "prebuild": "rimraf dist out-tsc",
     "start": "webpack-dev-server --open --config ./webpack/webpack.dev.js",
     "tagVersion": "node ./tasks/tag-version",
-    "test": "node ./tasks/test"
+    "test": "node ./tasks/test",
+    "compodoc": "./node_modules/.bin/compodoc src -p tsconfig.json --disablePrivateOrInternalSupport"
   },
   "keywords": [],
   "author": "",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^5.0.0",
+    "@compodoc/compodoc": "^1.0.5",
     "@types/jasmine": "^2.0.0",
     "@types/node": "^8.0.0",
     "angular-librarian": "{{ librarianVersion }}",


### PR DESCRIPTION
Refering to this issue: https://github.com/gonzofish/angular-librarian/issues/74 I found a clean and simple way to automatically generate docs for the project after the build is done.