### PR TITLE
fix: failing rollup bundling - cannot read property 'slice' of undefined

### DIFF
--- a/commands/initial/templates/tasks/rollup.js
+++ b/commands/initial/templates/tasks/rollup.js
@@ -69,14 +69,15 @@ const doRollup = (libName, dirs) => {
         fesm5Config,
         minUmdConfig,
         umdConfig
-    ].map(config =>
+    ].map(config => {
         rollup.rollup(config)
             .then(bundle => bundle.write({
                 file: config.output.file,
                 format: config.output.format,
                 ...config
             }))
-        );
+        }
+    );
 
     return Promise.all(bundles);
 };


### PR DESCRIPTION
fixes https://github.com/gonzofish/angular-librarian/issues/89