### PR TITLE
Fix @angular/compiler version

### DIFF
--- a/commands/initial/templates/tasks/build.js
+++ b/commands/initial/templates/tasks/build.js
@@ -43,7 +43,7 @@ const getAngularCompilerVersion = () => {
 
     if (compilerLine) {
         version = compilerLine.match(/\bangular\/compiler@[^\s]+\s?/) || [''];
-        version = version[0].trim().replace('angular/compiler@', '');
+        version = version[0].trim().replace('angular/compiler@', '').replace('^', '');
     }
 
     if (!version || version === '(empty)') {


### PR DESCRIPTION
This will fix cases when the command:

    npm list --depth=0 '@angular/compiler'

returns a line like this `@angular/compiler@^5.0.0`, which will trigger an error when you do the following comparison:

```js
const majorCompilerVersion = +compilerVersion.split('.')[0];

if (majorCompilerVersion >= 5) {
  // ...
}
```

Because in these cases `majorCompilerVersion` will be `NaN`.